### PR TITLE
refactor: route dev script through Turborepo

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,7 +4,7 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vite",
+		"dev": "tauri dev",
 		"build": "tsc && vite build",
 		"typecheck": "tsc --noEmit",
 		"preview": "vite preview",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,8 +4,8 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vite",
-		"dev:tauri": "tauri dev",
+		"dev": "tauri dev",
+		"dev:vite": "vite",
 		"build": "tsc && vite build",
 		"typecheck": "tsc --noEmit",
 		"preview": "vite preview",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,7 +4,8 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"dev": "tauri dev",
+		"dev": "vite",
+		"dev:tauri": "tauri dev",
 		"build": "tsc && vite build",
 		"typecheck": "tsc --noEmit",
 		"preview": "vite preview",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
 	"version": "0.1.0",
 	"identifier": "sh.0x1f320.submarine",
 	"build": {
-		"beforeDevCommand": "pnpm dev",
+		"beforeDevCommand": "pnpm run dev:vite",
 		"devUrl": "http://localhost:1420",
 		"beforeBuildCommand": "pnpm build",
 		"frontendDist": "../dist"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"dev": "turbo dev:tauri",
+		"dev": "turbo dev",
 		"build": "turbo run build",
 		"typecheck": "turbo run typecheck",
 		"check": "biome check .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"dev": "turbo dev:tauri dev",
+		"dev": "turbo dev:tauri",
 		"build": "turbo run build",
 		"typecheck": "turbo run typecheck",
 		"check": "biome check .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"dev": "pnpm --filter @submarine/desktop tauri dev",
+		"dev": "turbo dev",
 		"build": "turbo run build",
 		"typecheck": "turbo run typecheck",
 		"check": "biome check .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"dev": "turbo dev",
+		"dev": "turbo dev:tauri dev",
 		"build": "turbo run build",
 		"typecheck": "turbo run typecheck",
 		"check": "biome check .",

--- a/turbo.json
+++ b/turbo.json
@@ -9,12 +9,7 @@
 			"cache": false,
 			"persistent": true
 		},
-		"dev:tauri": {
-			"dependsOn": ["^dev"],
-			"cache": false,
-			"persistent": true
-		},
-		"typecheck": {
+				"typecheck": {
 			"dependsOn": ["^build"]
 		},
 		"check": {

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,7 @@
 			"persistent": true
 		},
 		"dev:tauri": {
+			"dependsOn": ["^dev"],
 			"cache": false,
 			"persistent": true
 		},

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
 		},
 		"dev": {
 			"cache": false,
-			"persistent": true
+			"persistent": true,
+			"ui": "tui"
 		},
 				"typecheck": {
 			"dependsOn": ["^build"]

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,10 @@
 			"cache": false,
 			"persistent": true
 		},
+		"dev:tauri": {
+			"cache": false,
+			"persistent": true
+		},
 		"typecheck": {
 			"dependsOn": ["^build"]
 		},

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://turbo.build/schema.json",
+	"ui": "tui",
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],
@@ -7,8 +8,7 @@
 		},
 		"dev": {
 			"cache": false,
-			"persistent": true,
-			"ui": "tui"
+			"persistent": true
 		},
 				"typecheck": {
 			"dependsOn": ["^build"]


### PR DESCRIPTION
## Summary
- Root `dev` script now uses `turbo dev` instead of directly invoking `pnpm --filter @submarine/desktop tauri dev`
- Desktop `dev` script changed to `tauri dev`, with a separate `dev:vite` script used by Tauri's `beforeDevCommand` to avoid recursion
- Enabled Turborepo TUI for interactive terminal UI during dev
- All workspace packages' dev scripts (desktop: tauri dev, mcp/react: tsc --watch) now run concurrently via turbo

🤖 Generated with [Claude Code](https://claude.com/claude-code)