### PR TITLE
chore: gitignore .cargo/ for local sccache config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ dist
 dist-ssr
 *.local
 
-# Cargo local config
-.cargo/
-
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist
 dist-ssr
 *.local
 
+# Cargo local config
+.cargo/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/apps/desktop/src-tauri/.cargo/config.toml
+++ b/apps/desktop/src-tauri/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustc-wrapper = "sccache"


### PR DESCRIPTION
## Summary

- Add `apps/desktop/src-tauri/.cargo/config.toml` with `sccache` as `rustc-wrapper`, enabling shared Rust compilation cache across git worktrees.
- This significantly reduces rebuild times when switching between worktrees — each worktree keeps its own `target/` but shares compiled artifact cache via sccache.

## Test plan

- [ ] `brew install sccache` and run `pnpm dev` — verify sccache is used (`sccache --show-stats`)
- [ ] Create a new worktree and run `pnpm dev` — verify cache hits from the first build

🤖 Generated with [Claude Code](https://claude.com/claude-code)