### PR TITLE
fix(web): prevent white flash on dark mode startup

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -5,6 +5,19 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri + React + Typescript</title>
+    <style>
+      html.dark { background-color: oklch(0.141 0.005 285.823); }
+    </style>
+    <script>
+      (function () {
+        var theme = localStorage.getItem("theme") || "system";
+        var dark =
+          theme === "dark" ||
+          (theme === "system" &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches);
+        if (dark) document.documentElement.classList.add("dark");
+      })();
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- Fix white flash (FOUC) on app start/reload in dark mode
- Add inline `<style>` and blocking `<script>` in `index.html` to apply dark theme before CSS/React loads

## Test plan
- [ ] Set dark mode, restart app — dark background appears immediately with no white flash
- [ ] With system theme set to dark and `theme=system`, verify same behavior
- [ ] Light mode works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)