### PR TITLE
ci: split CI into per-package workflows with turbo affected detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,62 +10,58 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
-  check:
-    name: Check
+  check-affected:
+    name: Check affected packages
     runs-on: ubuntu-latest
+    outputs:
+      desktop: ${{ steps.affected.outputs.desktop }}
+      react: ${{ steps.affected.outputs.react }}
+      mcp: ${{ steps.affected.outputs.mcp }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/desktop/src-tauri -> target
-      - run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm check
-      - run: pnpm typecheck
-      - name: cargo fmt & clippy
-        working-directory: apps/desktop/src-tauri
-        run: cargo fmt --check && cargo clippy -- -D warnings
 
-  build:
-    name: Build (${{ matrix.os }})
-    needs: check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - os: ubuntu-latest
-            deps: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev
-          - os: macos-latest
-            deps: ""
-          - os: windows-latest
-            deps: ""
-    steps:
-      - uses: actions/checkout@v4
+      - name: Fetch base ref
+        id: base-ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            echo "base=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
+          else
+            git fetch --no-tags --depth=2 origin "${GITHUB_REF#refs/heads/}"
+            echo "base=HEAD~1" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/desktop/src-tauri -> target
-      - name: Install system dependencies
-        if: matrix.deps != ''
-        run: ${{ matrix.deps }}
+
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @submarine/desktop tauri build
+
+      - name: Detect affected packages
+        id: affected
+        run: .github/workflows/scripts/detect-affected-apps.sh "${{ steps.base-ref.outputs.base }}"
+
+  desktop:
+    name: Desktop
+    needs: check-affected
+    if: needs.check-affected.outputs.desktop == 'true'
+    uses: ./.github/workflows/desktop.yml
+
+  react:
+    name: React
+    needs: check-affected
+    if: needs.check-affected.outputs.react == 'true'
+    uses: ./.github/workflows/react.yml
+
+  mcp:
+    name: MCP
+    needs: check-affected
+    if: needs.check-affected.outputs.mcp == 'true'
+    uses: ./.github/workflows/mcp.yml

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,64 @@
+name: Desktop
+
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri -> target
+      - run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm turbo run typecheck --filter=@submarine/desktop...
+      - name: cargo fmt & clippy
+        working-directory: apps/desktop/src-tauri
+        run: cargo fmt --check && cargo clippy -- -D warnings
+
+  build:
+    name: Build (${{ matrix.os }})
+    needs: check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            deps: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev
+          - os: macos-latest
+            deps: ""
+          - os: windows-latest
+            deps: ""
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri -> target
+      - name: Install system dependencies
+        if: matrix.deps != ''
+        run: ${{ matrix.deps }}
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @submarine/desktop tauri build

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -1,0 +1,19 @@
+name: MCP
+
+on:
+  workflow_call:
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm turbo run typecheck --filter=@submarine/mcp...

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -1,0 +1,33 @@
+name: React
+
+on:
+  workflow_call:
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm turbo run typecheck --filter=@submarine/react...
+
+  build:
+    name: Build
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm turbo run build --filter=@submarine/react...

--- a/.github/workflows/scripts/detect-affected-apps.sh
+++ b/.github/workflows/scripts/detect-affected-apps.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: detect-affected-apps.sh <base_ref>
+#
+# Analyzes changes against the given base ref using turborepo's dependency
+# graph to determine which packages are affected.
+#
+# Scans both apps/ and packages/ directories. If a shared package
+# (e.g. typescript-config) is changed, turborepo correctly flags all
+# downstream dependents as affected.
+
+BASE="$1"
+
+AFFECTED_JSON=$(npx turbo run build --filter="...[$BASE]" --dry-run=json 2>/dev/null)
+
+for dir in apps/*/ packages/*/; do
+  name=$(basename "$dir")
+  found=$(echo "$AFFECTED_JSON" | jq -r \
+    --arg name "$name" \
+    'if [.tasks[] | select(.package == $name)] | length > 0
+     then "true" else "false" end')
+  echo "$name=$found" >> "$GITHUB_OUTPUT"
+done


### PR DESCRIPTION
## Summary
- Split the monolithic CI workflow into per-package reusable workflows (`desktop.yml`, `react.yml`, `mcp.yml`)
- Added `check-affected` job using `turbo run build --dry-run=json` to detect which packages are affected by a change
- Each package workflow runs its own Biome lint, typecheck, and build steps independently
- Unaffected packages are skipped entirely (e.g., `packages/react` changes no longer trigger a desktop Tauri build)

## Test plan
- [ ] Verify `check-affected` job correctly detects affected packages on a PR
- [ ] Confirm desktop workflow is skipped when only `packages/react` is changed
- [ ] Confirm all workflows trigger when `packages/typescript-config` is changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)