### PR TITLE
ci: resolve HEAD~1 to SHA for paths-filter base ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             echo "base=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
           else
             git fetch --no-tags --depth=2 origin "${GITHUB_REF#refs/heads/}"
-            echo "base=HEAD~1" >> "$GITHUB_OUTPUT"
+            echo "base=$(git rev-parse HEAD~1)" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: dorny/paths-filter@v3


### PR DESCRIPTION
## Summary
- On push events, `dorny/paths-filter` failed because `HEAD~1` was passed as the base ref, which is not a valid git refspec for `git fetch`
- Resolves `HEAD~1` to its actual commit SHA via `git rev-parse` before passing it to `paths-filter`
- Fixes https://github.com/0x1f320/submarine/actions/runs/24004823750

## Test plan
- [ ] Verify CI passes on this PR (push event triggers the fixed code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)