### PR TITLE
feat(desktop): add Page/Commit models with data persistence and route UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,6 +1889,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,6 +2886,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3101,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "num-bigint"
@@ -4408,6 +4445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4944,6 +4987,7 @@ dependencies = [
  "serde",
  "socketioxide-core",
  "socketioxide-parser-common",
+ "state",
  "thiserror 2.0.18",
  "tokio",
  "tower-layer",
@@ -5035,6 +5079,7 @@ dependencies = [
  "chrono",
  "paste",
  "rustc_version",
+ "serde_json",
  "specta-macros",
 ]
 
@@ -5311,6 +5356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "state"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5408,6 +5462,7 @@ dependencies = [
  "tauri-specta",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5523,7 +5578,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5601,7 +5656,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5702,7 +5757,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -5728,7 +5783,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5753,7 +5808,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6222,6 +6277,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -6231,12 +6298,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -6471,6 +6541,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -6760,7 +6836,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -6784,7 +6860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -6842,6 +6918,15 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7467,7 +7552,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,14 +22,15 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sea-orm = { version = "2.0.0-rc.37", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros", "with-chrono"] }
+sea-orm = { version = "2.0.0-rc.37", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros", "with-chrono", "with-json"] }
 sea-orm-migration = { version = "2.0.0-rc.37", features = ["sqlx-sqlite", "runtime-tokio-rustls"] }
-specta = { version = "=2.0.0-rc.24", features = ["chrono"] }
+specta = { version = "=2.0.0-rc.24", features = ["chrono", "serde_json"] }
 specta-typescript = "0.0.11"
 tauri-specta = { version = "=2.0.0-rc.24", features = ["typescript"] }
 chrono = { version = "0.4", features = ["serde"] }
 submarine-types = { path = "../../../packages/types" }
-socketioxide = "0.18"
+socketioxide = { version = "0.18", features = ["state", "extensions"] }
+url = "2"
 tokio = { version = "1", features = ["net"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 tracing = "0.1"

--- a/apps/desktop/src-tauri/src/command/commit.rs
+++ b/apps/desktop/src-tauri/src/command/commit.rs
@@ -1,0 +1,48 @@
+use chrono::{DateTime, Utc};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder};
+use serde::Serialize;
+use specta::Type;
+use tauri::State;
+
+use crate::entity::commit;
+
+#[derive(Debug, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Commit {
+    pub id: i32,
+    pub page_id: i32,
+    pub phase: String,
+    pub timestamp: f64,
+    pub component_count: i32,
+    pub total_time: f64,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<commit::Model> for Commit {
+    fn from(m: commit::Model) -> Self {
+        Self {
+            id: m.id,
+            page_id: m.page_id,
+            phase: m.phase,
+            timestamp: m.timestamp,
+            component_count: m.component_count,
+            total_time: m.total_time,
+            created_at: m.created_at,
+        }
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn list_commits(
+    db: State<'_, DatabaseConnection>,
+    page_id: i32,
+) -> Result<Vec<Commit>, String> {
+    commit::Entity::find()
+        .filter(commit::Column::PageId.eq(page_id))
+        .order_by_desc(commit::Column::Id)
+        .all(db.inner())
+        .await
+        .map(|commits| commits.into_iter().map(Commit::from).collect())
+        .map_err(|e| e.to_string())
+}

--- a/apps/desktop/src-tauri/src/command/mod.rs
+++ b/apps/desktop/src-tauri/src/command/mod.rs
@@ -1,2 +1,4 @@
+pub mod commit;
+pub mod page;
 pub mod project;
 pub mod socket;

--- a/apps/desktop/src-tauri/src/command/page.rs
+++ b/apps/desktop/src-tauri/src/command/page.rs
@@ -1,0 +1,42 @@
+use chrono::{DateTime, Utc};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use serde::Serialize;
+use specta::Type;
+use tauri::State;
+
+use crate::entity::page;
+
+#[derive(Debug, Serialize, Type)]
+pub struct Page {
+    pub id: i32,
+    pub project_id: i32,
+    pub url: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<page::Model> for Page {
+    fn from(m: page::Model) -> Self {
+        Self {
+            id: m.id,
+            project_id: m.project_id,
+            url: m.url,
+            created_at: m.created_at,
+            updated_at: m.updated_at,
+        }
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn list_pages(
+    db: State<'_, DatabaseConnection>,
+    project_id: i32,
+) -> Result<Vec<Page>, String> {
+    page::Entity::find()
+        .filter(page::Column::ProjectId.eq(project_id))
+        .all(db.inner())
+        .await
+        .map(|pages| pages.into_iter().map(Page::from).collect())
+        .map_err(|e| e.to_string())
+}

--- a/apps/desktop/src-tauri/src/command/project.rs
+++ b/apps/desktop/src-tauri/src/command/project.rs
@@ -20,10 +20,12 @@ pub async fn create_project(
     db: State<'_, DatabaseConnection>,
     name: String,
     path: String,
+    host: String,
 ) -> Result<project::Model, String> {
     let model = project::ActiveModel {
         name: Set(name),
         path: Set(path),
+        host: Set(host),
         ..Default::default()
     };
     model.insert(db.inner()).await.map_err(|e| e.to_string())

--- a/apps/desktop/src-tauri/src/command/socket.rs
+++ b/apps/desktop/src-tauri/src/command/socket.rs
@@ -21,5 +21,6 @@ pub fn get_socket_status(state: State<'_, SocketState>) -> SocketStatus {
         listening: true,
         port: state.port,
         connected_clients,
+        connected_projects: state.connected_projects.list(),
     }
 }

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -1,4 +1,4 @@
-use sea_orm::sea_query::Table;
+use sea_orm::sea_query::{ColumnDef, Table};
 use sea_orm::{Database, DatabaseConnection, DbErr, Schema};
 use sea_orm_migration::prelude::*;
 
@@ -8,9 +8,18 @@ pub struct Migrator;
 
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(CreateProjectTable)]
+        vec![
+            Box::new(CreateProjectTable),
+            Box::new(CreatePageTable),
+            Box::new(CreateCommitTable),
+            Box::new(AddHostToProject),
+        ]
     }
 }
+
+// ---------------------------------------------------------------------------
+// m20260405_000001 — Create project table
+// ---------------------------------------------------------------------------
 
 struct CreateProjectTable;
 
@@ -32,6 +41,104 @@ impl MigrationTrait for CreateProjectTable {
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
             .drop_table(Table::drop().table(entity::project::Entity).to_owned())
+            .await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// m20260406_000001 — Create page table
+// ---------------------------------------------------------------------------
+
+struct CreatePageTable;
+
+impl MigrationName for CreatePageTable {
+    fn name(&self) -> &'static str {
+        "m20260406_000001_create_page"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for CreatePageTable {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let schema = Schema::new(manager.get_database_backend());
+        manager
+            .create_table(schema.create_table_from_entity(entity::page::Entity))
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(entity::page::Entity).to_owned())
+            .await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// m20260406_000002 — Create commit table
+// ---------------------------------------------------------------------------
+
+struct CreateCommitTable;
+
+impl MigrationName for CreateCommitTable {
+    fn name(&self) -> &'static str {
+        "m20260406_000002_create_commit"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for CreateCommitTable {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let schema = Schema::new(manager.get_database_backend());
+        manager
+            .create_table(schema.create_table_from_entity(entity::commit::Entity))
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(entity::commit::Entity).to_owned())
+            .await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// m20260406_000003 — Add host column to project
+// ---------------------------------------------------------------------------
+
+struct AddHostToProject;
+
+impl MigrationName for AddHostToProject {
+    fn name(&self) -> &'static str {
+        "m20260406_000003_add_host_to_project"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddHostToProject {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(entity::project::Entity)
+                    .add_column(
+                        ColumnDef::new(entity::project::Column::Host)
+                            .string()
+                            .not_null()
+                            .default(""),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(entity::project::Entity)
+                    .drop_column(entity::project::Column::Host)
+                    .to_owned(),
+            )
             .await
     }
 }

--- a/apps/desktop/src-tauri/src/entity/commit.rs
+++ b/apps/desktop/src-tauri/src/entity/commit.rs
@@ -1,0 +1,52 @@
+use sea_orm::entity::prelude::*;
+use sea_orm::ActiveValue::Set;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "commit")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub page_id: i32,
+    /// "mount" | "update" | "unmount"
+    pub phase: String,
+    /// Timestamp from the React commit event (ms since epoch).
+    pub timestamp: f64,
+    /// Number of components in the tree.
+    pub component_count: i32,
+    /// Sum of all component totalTime values.
+    pub total_time: f64,
+    /// Full `ComponentNode` tree serialized as JSON.
+    #[sea_orm(column_type = "Json")]
+    pub tree_json: serde_json::Value,
+    pub created_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::page::Entity",
+        from = "Column::PageId",
+        to = "super::page::Column::Id"
+    )]
+    Page,
+}
+
+impl Related<super::page::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Page.def()
+    }
+}
+
+#[async_trait::async_trait]
+impl ActiveModelBehavior for ActiveModel {
+    async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if insert {
+            self.created_at = Set(chrono::Utc::now());
+        }
+        Ok(self)
+    }
+}

--- a/apps/desktop/src-tauri/src/entity/mod.rs
+++ b/apps/desktop/src-tauri/src/entity/mod.rs
@@ -1,1 +1,3 @@
+pub mod commit;
+pub mod page;
 pub mod project;

--- a/apps/desktop/src-tauri/src/entity/page.rs
+++ b/apps/desktop/src-tauri/src/entity/page.rs
@@ -1,29 +1,39 @@
 use sea_orm::entity::prelude::*;
 use sea_orm::ActiveValue::Set;
 use serde::{Deserialize, Serialize};
-use specta::Type;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize, Type)]
-#[sea_orm(table_name = "project")]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "page")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
-    pub name: String,
-    pub path: String,
-    pub host: String,
+    pub project_id: i32,
+    pub url: String,
     pub created_at: DateTimeUtc,
     pub updated_at: DateTimeUtc,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {
-    #[sea_orm(has_many = "super::page::Entity")]
-    Page,
+    #[sea_orm(
+        belongs_to = "super::project::Entity",
+        from = "Column::ProjectId",
+        to = "super::project::Column::Id"
+    )]
+    Project,
+    #[sea_orm(has_many = "super::commit::Entity")]
+    Commit,
 }
 
-impl Related<super::page::Entity> for Entity {
+impl Related<super::project::Entity> for Entity {
     fn to() -> RelationDef {
-        Relation::Page.def()
+        Relation::Project.def()
+    }
+}
+
+impl Related<super::commit::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Commit.def()
     }
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,8 @@ pub fn run() {
     let builder = Builder::<tauri::Wry>::new().commands(collect_commands![
         command::project::list_projects,
         command::project::create_project,
+        command::page::list_pages,
+        command::commit::list_commits,
         command::socket::get_socket_port,
         command::socket::get_socket_status,
     ]);
@@ -37,10 +39,10 @@ pub fn run() {
             ))
             .expect("Failed to initialize database");
 
-            app.manage(db);
+            // Socket.IO server (needs its own clone before db is moved into manage)
+            let socket_state = tauri::async_runtime::block_on(socket::start(db.clone()));
 
-            // Socket.IO server
-            let socket_state = tauri::async_runtime::block_on(socket::start());
+            app.manage(db);
             app.manage(socket_state);
 
             Ok(())

--- a/apps/desktop/src-tauri/src/socket.rs
+++ b/apps/desktop/src-tauri/src/socket.rs
@@ -185,7 +185,9 @@ async fn resolve_page(db: &DatabaseConnection, raw_url: &str) -> Result<(i32, i3
         .await
         .map_err(|e| e.to_string())?;
 
-    let proj = if let Some(p) = proj { p } else {
+    let proj = if let Some(p) = proj {
+        p
+    } else {
         let model = project::ActiveModel {
             name: Set(host.clone()),
             path: Set(String::new()),
@@ -203,7 +205,9 @@ async fn resolve_page(db: &DatabaseConnection, raw_url: &str) -> Result<(i32, i3
         .await
         .map_err(|e| e.to_string())?;
 
-    let pg = if let Some(p) = pg { p } else {
+    let pg = if let Some(p) = pg {
+        p
+    } else {
         let model = page::ActiveModel {
             project_id: Set(proj.id),
             url: Set(raw_url.to_string()),

--- a/apps/desktop/src-tauri/src/socket.rs
+++ b/apps/desktop/src-tauri/src/socket.rs
@@ -1,16 +1,42 @@
-use serde::Serialize;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
+use serde::{Deserialize, Serialize};
 use socketioxide::{
-    extract::{Data, SocketRef},
+    extract::{Data, Extension, SocketRef, State},
     SocketIo,
 };
-use submarine_types::CommitData;
+use submarine_types::{CommitData, ComponentNode};
 use tokio::net::TcpListener;
-use tracing::info;
+use tracing::{info, warn};
+use url::Url;
+
+use crate::entity::{commit, page, project};
+
+/// Shared set of project IDs with active socket connections.
+#[derive(Debug, Clone, Default)]
+pub struct ConnectedProjects(Arc<Mutex<HashSet<i32>>>);
+
+impl ConnectedProjects {
+    fn insert(&self, project_id: i32) {
+        self.0.lock().unwrap().insert(project_id);
+    }
+
+    fn remove(&self, project_id: i32) {
+        self.0.lock().unwrap().remove(&project_id);
+    }
+
+    pub fn list(&self) -> Vec<i32> {
+        self.0.lock().unwrap().iter().copied().collect()
+    }
+}
 
 /// Managed state holding Socket.IO server info.
 pub struct SocketState {
     pub port: u16,
     pub io: SocketIo,
+    pub connected_projects: ConnectedProjects,
 }
 
 /// Snapshot of the Socket.IO server status returned to the frontend.
@@ -23,17 +49,38 @@ pub struct SocketStatus {
     pub port: u16,
     /// Number of currently connected clients.
     pub connected_clients: usize,
+    /// Project IDs with active connections.
+    pub connected_projects: Vec<i32>,
 }
+
+/// Auth payload sent by `@submarine/react` on connect.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthData {
+    page_url: String,
+}
+
+/// Per-socket extension storing the resolved page ID.
+#[derive(Debug, Clone)]
+struct PageId(i32);
+
+/// Per-socket extension storing the resolved project ID.
+#[derive(Debug, Clone)]
+struct ProjectId(i32);
 
 /// Start the Socket.IO server on an OS-assigned port.
 ///
 /// Returns a [`SocketState`] that should be registered as Tauri managed state.
-pub async fn start() -> SocketState {
-    let (svc, io) = SocketIo::builder().build_svc();
+pub async fn start(db: DatabaseConnection) -> SocketState {
+    let connected_projects = ConnectedProjects::default();
+    let (svc, io) = SocketIo::builder()
+        .with_state(db)
+        .with_state(connected_projects.clone())
+        .build_svc();
 
     io.ns("/", on_connect);
 
-    let listener = TcpListener::bind("127.0.0.1:0")
+    let listener = TcpListener::bind("127.0.0.1:45323")
         .await
         .expect("Failed to bind Socket.IO listener");
 
@@ -43,6 +90,7 @@ pub async fn start() -> SocketState {
     let socket_state = SocketState {
         port,
         io: io.clone(),
+        connected_projects,
     };
 
     tauri::async_runtime::spawn(async move {
@@ -54,7 +102,7 @@ pub async fn start() -> SocketState {
                         hyper_util::rt::TokioExecutor::new(),
                     );
                     let _ = builder
-                        .serve_connection(hyper_util::rt::TokioIo::new(stream), svc)
+                        .serve_connection_with_upgrades(hyper_util::rt::TokioIo::new(stream), svc)
                         .await;
                 });
             }
@@ -65,15 +113,143 @@ pub async fn start() -> SocketState {
 }
 
 /// Called when a new Socket.IO client connects to the `/` namespace.
-async fn on_connect(socket: SocketRef) {
+async fn on_connect(
+    socket: SocketRef,
+    Data(auth): Data<AuthData>,
+    State(db): State<DatabaseConnection>,
+    State(connected): State<ConnectedProjects>,
+) {
     let sid = socket.id;
-    info!(%sid, "client connected");
+    info!(%sid, page_url = %auth.page_url, "client connected");
 
-    socket.on("commit", |Data::<CommitData>(commit)| async move {
-        info!(phase = ?commit.phase, "received commit");
-    });
+    match resolve_page(&db, &auth.page_url).await {
+        Ok((project_id, page_id)) => {
+            socket.extensions.insert(PageId(page_id));
+            socket.extensions.insert(ProjectId(project_id));
+            connected.insert(project_id);
+            info!(%sid, project_id, page_id, "page resolved");
+        }
+        Err(e) => {
+            warn!(%sid, error = %e, "failed to resolve page, commits will not be persisted");
+            return;
+        }
+    }
 
-    socket.on_disconnect(|socket: SocketRef| async move {
-        info!(sid = %socket.id, "client disconnected");
-    });
+    socket.on(
+        "commit",
+        |Data::<CommitData>(commit_data),
+         Extension::<PageId>(PageId(page_id)),
+         State::<DatabaseConnection>(db)| async move {
+            if let Err(e) = persist_commit(&db, page_id, &commit_data).await {
+                warn!(error = %e, "failed to persist commit");
+            }
+        },
+    );
+
+    socket.on_disconnect(
+        |socket: SocketRef,
+         Extension::<ProjectId>(ProjectId(project_id)),
+         State::<ConnectedProjects>(connected)| async move {
+            connected.remove(project_id);
+            info!(sid = %socket.id, project_id, "client disconnected");
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Database helpers
+// ---------------------------------------------------------------------------
+
+/// Parse the URL, find-or-create the Project (by host) and Page (by full URL).
+/// Returns `(project_id, page_id)`.
+async fn resolve_page(db: &DatabaseConnection, raw_url: &str) -> Result<(i32, i32), String> {
+    let parsed = Url::parse(raw_url).map_err(|e| format!("invalid URL: {e}"))?;
+
+    let host = match parsed.port() {
+        Some(port) => format!(
+            "{}://{}:{port}",
+            parsed.scheme(),
+            parsed.host_str().unwrap_or("localhost")
+        ),
+        None => format!(
+            "{}://{}",
+            parsed.scheme(),
+            parsed.host_str().unwrap_or("localhost")
+        ),
+    };
+
+    // Find or create project by host
+    let proj = project::Entity::find()
+        .filter(project::Column::Host.eq(&host))
+        .one(db)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let proj = if let Some(p) = proj { p } else {
+        let model = project::ActiveModel {
+            name: Set(host.clone()),
+            path: Set(String::new()),
+            host: Set(host),
+            ..Default::default()
+        };
+        model.insert(db).await.map_err(|e| e.to_string())?
+    };
+
+    // Find or create page by URL
+    let pg = page::Entity::find()
+        .filter(page::Column::ProjectId.eq(proj.id))
+        .filter(page::Column::Url.eq(raw_url))
+        .one(db)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let pg = if let Some(p) = pg { p } else {
+        let model = page::ActiveModel {
+            project_id: Set(proj.id),
+            url: Set(raw_url.to_string()),
+            ..Default::default()
+        };
+        model.insert(db).await.map_err(|e| e.to_string())?
+    };
+
+    Ok((proj.id, pg.id))
+}
+
+/// Count components in the tree recursively.
+fn count_components(node: &ComponentNode) -> i32 {
+    1 + node.children.iter().map(count_components).sum::<i32>()
+}
+
+/// Sum `total_time` across all nodes.
+fn sum_total_time(node: &ComponentNode) -> f64 {
+    let self_time = node.timings.as_ref().map_or(0.0, |t| t.total_time);
+    self_time + node.children.iter().map(sum_total_time).sum::<f64>()
+}
+
+/// Persist a single commit to the database.
+async fn persist_commit(
+    db: &DatabaseConnection,
+    page_id: i32,
+    data: &CommitData,
+) -> Result<(), String> {
+    let tree_json =
+        serde_json::to_value(&data.tree).map_err(|e| format!("failed to serialize tree: {e}"))?;
+
+    let phase = serde_json::to_value(&data.phase)
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_default();
+
+    let model = commit::ActiveModel {
+        page_id: Set(page_id),
+        phase: Set(phase),
+        timestamp: Set(data.timestamp),
+        component_count: Set(count_components(&data.tree)),
+        total_time: Set(sum_total_time(&data.tree)),
+        tree_json: Set(tree_json),
+        ..Default::default()
+    };
+
+    model.insert(db).await.map_err(|e| e.to_string())?;
+    Ok(())
 }

--- a/apps/desktop/src/bindings.ts
+++ b/apps/desktop/src/bindings.ts
@@ -5,16 +5,53 @@ import { invoke as __TAURI_INVOKE } from "@tauri-apps/api/core";
 /** Commands */
 export const commands = {
 	listProjects: () => typedError<Model[], string>(__TAURI_INVOKE("list_projects")),
-	createProject: (name: string, path: string) => typedError<Model, string>(__TAURI_INVOKE("create_project", { name, path })),
+	createProject: (name: string, path: string, host: string) => typedError<Model, string>(__TAURI_INVOKE("create_project", { name, path, host })),
+	listPages: (projectId: number) => typedError<Page[], string>(__TAURI_INVOKE("list_pages", { projectId })),
+	listCommits: (pageId: number) => typedError<Commit[], string>(__TAURI_INVOKE("list_commits", { pageId })),
+	// Return the port the Socket.IO server is listening on.
+	getSocketPort: () => __TAURI_INVOKE<number>("get_socket_port"),
+	// Return a snapshot of the Socket.IO server status.
+	getSocketStatus: () => __TAURI_INVOKE<SocketStatus>("get_socket_status"),
 };
 
 /* Types */
+export type Commit = {
+	id: number,
+	pageId: number,
+	phase: string,
+	timestamp: number,
+	componentCount: number,
+	totalTime: number,
+	createdAt: string,
+};
+
 export type Model = {
 	id: number,
 	name: string,
 	path: string,
+	host: string,
 	created_at: string,
 	updated_at: string,
+};
+
+export type Page = {
+	id: number,
+	project_id: number,
+	url: string,
+	created_at: string,
+	updated_at: string,
+};
+
+// Snapshot of the Socket.IO server status returned to the frontend.
+export type SocketStatus = {
+	// Whether the server is listening for connections.
+	listening: boolean,
+	// Port the server is bound to.
+	port: number,
+	// Number of currently connected clients.
+	connectedClients: number,
+	// Project IDs with active connections.
+	connectedProjects: number[],
 };
 
 /* Tauri Specta runtime */

--- a/apps/desktop/src/components/header.tsx
+++ b/apps/desktop/src/components/header.tsx
@@ -1,8 +1,8 @@
+import { useEffect, useState } from "react";
 import { commands } from "@/bindings";
 import { Button } from "@/components/ui/button";
 import type { useTheme } from "@/hooks/use-theme";
 import { useProjectStore } from "@/stores/project-store";
-import { useEffect, useState } from "react";
 
 type Theme = ReturnType<typeof useTheme>["theme"];
 

--- a/apps/desktop/src/components/header.tsx
+++ b/apps/desktop/src/components/header.tsx
@@ -1,6 +1,8 @@
+import { commands } from "@/bindings";
 import { Button } from "@/components/ui/button";
 import type { useTheme } from "@/hooks/use-theme";
 import { useProjectStore } from "@/stores/project-store";
+import { useEffect, useState } from "react";
 
 type Theme = ReturnType<typeof useTheme>["theme"];
 
@@ -67,6 +69,11 @@ export function Header({
 	const selectedProject = useProjectStore((s) => s.selectedProject);
 	const title = selectedProject?.name ?? "Submarine";
 
+	const [port, setPort] = useState<number | null>(null);
+	useEffect(() => {
+		commands.getSocketPort().then(setPort);
+	}, []);
+
 	return (
 		<header
 			data-tauri-drag-region
@@ -77,6 +84,15 @@ export function Header({
 			</h1>
 
 			<div className="flex items-center gap-2">
+				{port !== null && (
+					<span className="flex items-center gap-2.5 rounded-md border bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground select-none">
+						<span className="relative flex size-2">
+							<span className="absolute inline-flex size-full animate-ping rounded-full bg-green-400 opacity-75" />
+							<span className="relative inline-flex size-2 rounded-full bg-green-500" />
+						</span>
+						http://localhost:{port}
+					</span>
+				)}
 				<Button
 					size="icon"
 					variant="ghost"

--- a/apps/desktop/src/components/resize-handle.tsx
+++ b/apps/desktop/src/components/resize-handle.tsx
@@ -1,7 +1,7 @@
 export function ResizeHandle(props: React.HTMLAttributes<HTMLDivElement>) {
 	return (
 		<div
-			className="w-1 cursor-col-resize hover:bg-border active:bg-ring transition-colors shrink-0"
+			className="-ml-1 w-1 cursor-col-resize hover:bg-border active:bg-ring transition-colors shrink-0"
 			{...props}
 		/>
 	);

--- a/apps/desktop/src/components/route-sidebar.tsx
+++ b/apps/desktop/src/components/route-sidebar.tsx
@@ -1,0 +1,73 @@
+import { NavLink } from "react-router";
+import { Skeleton } from "@/components/ui/skeleton";
+import { usePages } from "@/hooks/use-pages";
+
+export function RouteSidebar({ projectId }: { projectId: number }) {
+	const { data: pages, isLoading } = usePages(projectId);
+
+	return (
+		<aside className="flex flex-col w-56 shrink-0 border-r bg-sidebar overflow-y-auto">
+			<div className="flex flex-col gap-1 px-2 pt-4">
+				<span className="px-2 text-xs font-medium text-muted-foreground">
+					Routes
+				</span>
+				<nav className="flex flex-col gap-0.5">
+					{isLoading ? (
+						<>
+							<div className="flex items-center gap-2 h-8 px-2">
+								<Skeleton className="h-3.5 w-32 rounded" />
+							</div>
+							<div className="flex items-center gap-2 h-8 px-2">
+								<Skeleton className="h-3.5 w-24 rounded" />
+							</div>
+						</>
+					) : !pages || pages.length === 0 ? (
+						<p className="px-2 py-1 text-xs text-muted-foreground/60">
+							No routes yet
+						</p>
+					) : (
+						pages.map((page) => {
+							const path = extractPath(page.url);
+							return (
+								<NavLink
+									key={page.id}
+									to={`/projects/${projectId}/pages/${page.id}`}
+									className={({ isActive }) =>
+										`flex items-center gap-2 h-8 px-2 rounded-md transition-colors text-sm text-left ${
+											isActive
+												? "bg-accent text-accent-foreground"
+												: "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+										}`
+									}
+								>
+									<svg
+										className="size-4 shrink-0"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										strokeWidth={2}
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										aria-hidden="true"
+									>
+										<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+										<path d="M14 2v4a2 2 0 0 0 2 2h4" />
+									</svg>
+									<span className="truncate font-mono text-xs">{path}</span>
+								</NavLink>
+							);
+						})
+					)}
+				</nav>
+			</div>
+		</aside>
+	);
+}
+
+function extractPath(url: string): string {
+	try {
+		return new URL(url).pathname || "/";
+	} catch {
+		return url;
+	}
+}

--- a/apps/desktop/src/components/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar.tsx
@@ -13,9 +13,7 @@ export function Sidebar({ width }: { width: number }) {
 		queryFn: () => commands.getSocketStatus(),
 		refetchInterval: 2000,
 	});
-	const connectedProjects = new Set(
-		socketStatus?.connectedProjects ?? [],
-	);
+	const connectedProjects = new Set(socketStatus?.connectedProjects ?? []);
 
 	return (
 		<aside

--- a/apps/desktop/src/components/sidebar.tsx
+++ b/apps/desktop/src/components/sidebar.tsx
@@ -1,4 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
 import { NavLink } from "react-router";
+import { commands } from "@/bindings";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useProjects } from "@/hooks/use-projects";
 import { useProjectStore } from "@/stores/project-store";
@@ -6,6 +8,14 @@ import { useProjectStore } from "@/stores/project-store";
 export function Sidebar({ width }: { width: number }) {
 	const { data: projects, isLoading } = useProjects();
 	const selectProject = useProjectStore((s) => s.selectProject);
+	const { data: socketStatus } = useQuery({
+		queryKey: ["socketStatus"],
+		queryFn: () => commands.getSocketStatus(),
+		refetchInterval: 2000,
+	});
+	const connectedProjects = new Set(
+		socketStatus?.connectedProjects ?? [],
+	);
 
 	return (
 		<aside
@@ -62,7 +72,15 @@ export function Sidebar({ width }: { width: number }) {
 								>
 									<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2z" />
 								</svg>
-								<span className="truncate">{project.name}</span>
+								<span className="truncate flex-1">{project.name}</span>
+								{connectedProjects.has(project.id) ? (
+									<span className="relative flex size-1.5 shrink-0">
+										<span className="absolute inline-flex size-full animate-ping rounded-full bg-green-400 opacity-75" />
+										<span className="relative inline-flex size-2 rounded-full bg-green-500" />
+									</span>
+								) : (
+									<span className="size-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
+								)}
 							</NavLink>
 						))
 					)}

--- a/apps/desktop/src/hooks/use-commits.ts
+++ b/apps/desktop/src/hooks/use-commits.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { commands } from "@/bindings";
+
+export function useCommits(pageId: number) {
+	return useQuery({
+		queryKey: ["commits", pageId],
+		queryFn: async () => {
+			const result = await commands.listCommits(pageId);
+			if (result.status === "error") {
+				throw new Error(result.error);
+			}
+			return result.data;
+		},
+		refetchInterval: 2000,
+	});
+}

--- a/apps/desktop/src/hooks/use-pages.ts
+++ b/apps/desktop/src/hooks/use-pages.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { commands } from "@/bindings";
+
+export function usePages(projectId: number) {
+	return useQuery({
+		queryKey: ["pages", projectId],
+		queryFn: async () => {
+			const result = await commands.listPages(projectId);
+			if (result.status === "error") {
+				throw new Error(result.error);
+			}
+			return result.data;
+		},
+	});
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router";
 import App from "./app";
 import { NoProject } from "./pages/no-project";
+import { PageDetail } from "./pages/page-detail";
 import { Project } from "./pages/project";
 
 const queryClient = new QueryClient();
@@ -15,7 +16,9 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 				<Routes>
 					<Route element={<App />}>
 						<Route index element={<NoProject />} />
-						<Route path="projects/:projectId" element={<Project />} />
+						<Route path="projects/:projectId" element={<Project />}>
+							<Route path="pages/:pageId" element={<PageDetail />} />
+						</Route>
 					</Route>
 				</Routes>
 			</BrowserRouter>

--- a/apps/desktop/src/pages/page-detail.tsx
+++ b/apps/desktop/src/pages/page-detail.tsx
@@ -47,10 +47,7 @@ export function PageDetail() {
 					value={avgTime.toFixed(1)}
 					unit="ms"
 				/>
-				<SummaryCard
-					label="Avg Components"
-					value={avgComponents.toFixed(0)}
-				/>
+				<SummaryCard label="Avg Components" value={avgComponents.toFixed(0)} />
 			</div>
 
 			<div className="rounded-md border">

--- a/apps/desktop/src/pages/page-detail.tsx
+++ b/apps/desktop/src/pages/page-detail.tsx
@@ -1,0 +1,118 @@
+import { useParams } from "react-router";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { useCommits } from "@/hooks/use-commits";
+
+export function PageDetail() {
+	const { pageId } = useParams();
+	const numericPageId = Number(pageId);
+	const { data: commits, isLoading } = useCommits(numericPageId);
+
+	if (isLoading) {
+		return (
+			<div className="p-4 space-y-3">
+				<Skeleton className="h-5 w-48 rounded" />
+				<Skeleton className="h-64 w-full rounded" />
+			</div>
+		);
+	}
+
+	if (!commits || commits.length === 0) {
+		return (
+			<div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+				No commits yet
+			</div>
+		);
+	}
+
+	const totalRenders = commits.length;
+	const avgTime =
+		commits.reduce((sum, c) => sum + c.totalTime, 0) / totalRenders;
+	const avgComponents =
+		commits.reduce((sum, c) => sum + c.componentCount, 0) / totalRenders;
+
+	return (
+		<div className="p-4 space-y-4">
+			<div className="grid grid-cols-3 gap-3">
+				<SummaryCard label="Total Commits" value={totalRenders.toString()} />
+				<SummaryCard
+					label="Avg Total Time"
+					value={avgTime.toFixed(1)}
+					unit="ms"
+				/>
+				<SummaryCard
+					label="Avg Components"
+					value={avgComponents.toFixed(0)}
+				/>
+			</div>
+
+			<div className="rounded-md border">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead className="w-16">#</TableHead>
+							<TableHead>Phase</TableHead>
+							<TableHead className="text-right">Components</TableHead>
+							<TableHead className="text-right">Total Time</TableHead>
+							<TableHead className="text-right">Time</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{commits.map((commit) => (
+							<TableRow key={commit.id}>
+								<TableCell className="font-mono text-xs text-muted-foreground">
+									{commit.id}
+								</TableCell>
+								<TableCell>
+									<span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs">
+										{commit.phase}
+									</span>
+								</TableCell>
+								<TableCell className="text-right font-mono text-sm">
+									{commit.componentCount}
+								</TableCell>
+								<TableCell className="text-right font-mono text-sm">
+									{commit.totalTime.toFixed(1)}ms
+								</TableCell>
+								<TableCell className="text-right text-xs text-muted-foreground">
+									{new Date(commit.createdAt).toLocaleTimeString()}
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			</div>
+		</div>
+	);
+}
+
+function SummaryCard({
+	label,
+	value,
+	unit,
+}: {
+	label: string;
+	value: string;
+	unit?: string;
+}) {
+	return (
+		<div className="rounded-md border p-3">
+			<p className="text-xs text-muted-foreground">{label}</p>
+			<p className="text-xl font-semibold">
+				{value}
+				{unit && (
+					<span className="text-sm font-normal text-muted-foreground ml-0.5">
+						{unit}
+					</span>
+				)}
+			</p>
+		</div>
+	);
+}

--- a/apps/desktop/src/pages/project.tsx
+++ b/apps/desktop/src/pages/project.tsx
@@ -1,15 +1,11 @@
 import { useEffect } from "react";
-import { useParams } from "react-router";
-import { MetricCard } from "@/components/metric-card";
-import { RenderList } from "@/components/render-list";
-import { Timeline } from "@/components/timeline";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Outlet, useParams } from "react-router";
+import { RouteSidebar } from "@/components/route-sidebar";
 import { useProjects } from "@/hooks/use-projects";
 import { useProjectStore } from "@/stores/project-store";
 
 export function Project() {
-	const { projectId } = useParams();
+	const { projectId, pageId } = useParams();
 	const { data: projects } = useProjects();
 	const { selectedProject, selectProject } = useProjectStore();
 
@@ -20,50 +16,20 @@ export function Project() {
 		selectProject(project ?? null);
 	}, [projectId, projects, selectedProject, selectProject]);
 
-	return (
-		<div className="p-4 space-y-4">
-			<div className="grid grid-cols-4 gap-3">
-				<MetricCard
-					label="Total Renders"
-					value="24"
-					description="+12% vs last session"
-				/>
-				<MetricCard
-					label="Avg Render Time"
-					value="2.1"
-					unit="ms"
-					description="-0.4ms improvement"
-				/>
-				<MetricCard label="Unnecessary Renders" value="7" />
-				<MetricCard label="Component Count" value="18" />
-			</div>
+	const numericProjectId = Number(projectId);
 
-			<Tabs defaultValue="renders">
-				<TabsList>
-					<TabsTrigger value="renders">Component Renders</TabsTrigger>
-					<TabsTrigger value="timeline">Timeline</TabsTrigger>
-				</TabsList>
-				<TabsContent value="renders">
-					<Card>
-						<CardHeader>
-							<CardTitle className="text-sm">Render Activity</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<RenderList />
-						</CardContent>
-					</Card>
-				</TabsContent>
-				<TabsContent value="timeline">
-					<Card>
-						<CardHeader>
-							<CardTitle className="text-sm">Render Timeline</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<Timeline />
-						</CardContent>
-					</Card>
-				</TabsContent>
-			</Tabs>
+	return (
+		<div className="flex h-full">
+			<RouteSidebar projectId={numericProjectId} />
+			<div className="flex-1 overflow-y-auto">
+				{pageId ? (
+					<Outlet />
+				) : (
+					<div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+						Select a route
+					</div>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/packages/react/src/transport.ts
+++ b/packages/react/src/transport.ts
@@ -7,6 +7,8 @@ import type { CommitData, Unsubscribe } from "./types.js";
 export interface ConnectOptions {
 	/** Socket.IO server URL (e.g. "http://localhost:9284"). */
 	url: string;
+	/** Page URL to associate commits with. Defaults to `window.location.href`. */
+	pageUrl?: string;
 }
 
 /** Active socket instance, if connected. */
@@ -25,12 +27,17 @@ export function connect(options: ConnectOptions): Unsubscribe {
 		return () => disconnect();
 	}
 
+	const pageUrl =
+		options.pageUrl ??
+		(typeof window !== "undefined" ? window.location.href : "");
+
 	socket = io(options.url, {
 		transports: ["websocket"],
 		reconnection: true,
 		reconnectionAttempts: Infinity,
 		reconnectionDelay: 1000,
 		reconnectionDelayMax: 5000,
+		auth: { pageUrl },
 	});
 
 	unsubscribe = subscribe((data: CommitData) => {


### PR DESCRIPTION
## Summary
- Add `Page` and `Commit` SeaORM entities with migrations, and `host` field to `Project`
- Persist React commit data (component tree as JSON, phase, timing, component count) from Socket.IO into SQLite
- Send `pageUrl` from `@submarine/react` on connect; server auto-creates Project (by host:port) and Page (by full URL)
- Add per-project route sidebar with page detail view showing commit history table
- Show Socket.IO listening address in header, live connection status dots on projects in sidebar, and fix WebSocket upgrade (`serve_connection_with_upgrades`)

## Test plan
- [ ] Run `pnpm dev`, connect a test React app via `@submarine/react`, verify commits appear in SQLite
- [ ] Click a project → route → verify commit table loads with live data
- [ ] Disconnect the test app, verify green dot disappears from sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)